### PR TITLE
Can not pass &String and String to normal commands

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -69,8 +69,7 @@ macro_rules! as_redis_arg {
     };
 }
 
-impl<'a> RedisArg for &'a str {}
-
+as_redis_arg!(&str);
 as_redis_arg!(i8);
 as_redis_arg!(i16);
 as_redis_arg!(u16);

--- a/src/types.rs
+++ b/src/types.rs
@@ -70,6 +70,8 @@ macro_rules! as_redis_arg {
 }
 
 as_redis_arg!(&str);
+as_redis_arg!(&String);
+as_redis_arg!(String);
 as_redis_arg!(i8);
 as_redis_arg!(i16);
 as_redis_arg!(u16);


### PR DESCRIPTION
Looks no need such a constraint which is blocking normal commands to pass `&String` as parameters